### PR TITLE
Add `populate_dependency_context` to fix bug when using `InMemoryBroker`

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ async def app_shutdown():
 taskiq_fastapi.init(broker, "test_script:app")
 
 
-# We use TaskiqDepends here, becuase if we use FastAPIDepends fastapi
-# initilization will fail.
+# We use TaskiqDepends here, because if we use FastAPIDepends fastapi
+# initialization will fail.
 def get_redis_pool(request: Request = TaskiqDepends()) -> ConnectionPool:
     return request.app.state.redis_pool
 
@@ -119,4 +119,20 @@ async def getval_endpoint(
     async with Redis(connection_pool=pool, decode_responses=True) as redis:
         return await redis.get(key)
 
+```
+
+## Manually update dependency context
+
+When using `InMemoryBroker` it may be required to update the dependency context manually. This may also be useful when setting up tests.
+
+```py
+import taskiq_fastapi
+from taskiq import InMemoryBroker
+
+broker = InMemoryBroker()
+
+app = FastAPI()
+
+taskiq_fastapi.init(broker, "test_script:app")
+taskiq_fastapi.populate_dependency_context(broker, app)
 ```

--- a/taskiq_fastapi/__init__.py
+++ b/taskiq_fastapi/__init__.py
@@ -1,4 +1,4 @@
 """FastAPI integration for Taskiq project."""
-from taskiq_fastapi.initializator import init
+from taskiq_fastapi.initializator import init, populate_dependency_context
 
-__all__ = ["init"]
+__all__ = ["init", "populate_dependency_context"]

--- a/taskiq_fastapi/initializator.py
+++ b/taskiq_fastapi/initializator.py
@@ -67,14 +67,8 @@ def init(broker: AsyncBroker, app_path: str) -> None:
 
     if not isinstance(app, FastAPI):
         raise ValueError(f"'{app_path}' is not a FastAPI application.")
-    scope = {"app": app, "type": "http"}
 
-    broker.add_dependency_context(
-        {
-            Request: Request(scope=scope),
-            HTTPConnection: HTTPConnection(scope=scope),
-        },
-    )
+    populate_dependency_context(broker, app)
 
     broker.add_event_handler(
         TaskiqEvents.WORKER_STARTUP,
@@ -84,4 +78,27 @@ def init(broker: AsyncBroker, app_path: str) -> None:
     broker.add_event_handler(
         TaskiqEvents.WORKER_SHUTDOWN,
         shutdown_event_generator(app),
+    )
+
+
+def populate_dependency_context(broker: AsyncBroker, app: FastAPI) -> None:
+    """
+    Populate dependency context.
+
+    This function injects the Request and HTTPConnection
+    into the broker's dependency context.
+
+    It may be need to be called manually if you are using InMemoryBroker.
+
+    :param broker: current broker to use.
+    :param app: current application.
+    """
+
+    scope = {"app": app, "type": "http"}
+
+    broker.add_dependency_context(
+        {
+            Request: Request(scope=scope),
+            HTTPConnection: HTTPConnection(scope=scope),
+        },
     )


### PR DESCRIPTION
When using  `InMemoryBroker` the dependency context is never set. 

I have added `populate_dependency_context` so it can be set manually, as well as adding documentation to make users aware.
The function may also be useful when setting up tests. 

I also fixed some typos.