### PR TITLE
fix: remove startup/shutdown calls incompatible with Starlette 1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Development Status :: 3 - Alpha",
 ]
 keywords = ["taskiq", "tasks", "distributed", "async", "fastapi"]
-dependencies = ["taskiq>=0.8.0", "fastapi>=0.93.0"]
+dependencies = ["taskiq>=0.8.0", "fastapi>=0.133.0"]
 
 [dependency-groups]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Development Status :: 3 - Alpha",
 ]
 keywords = ["taskiq", "tasks", "distributed", "async", "fastapi"]
-dependencies = ["taskiq>=0.8.0", "fastapi>=0.133.0"]
+dependencies = ["taskiq>=0.8.0", "fastapi>=0.133.0,<1"]
 
 [dependency-groups]
 dev = [

--- a/taskiq_fastapi/initializator.py
+++ b/taskiq_fastapi/initializator.py
@@ -38,7 +38,6 @@ def startup_event_generator(
             raise ValueError(f"'{app_or_path}' is not a FastAPI application.")
 
         state.fastapi_app = app
-        await app.router.startup()
         state.lf_ctx = app.router.lifespan_context(app)
         asgi_state = await state.lf_ctx.__aenter__()
         populate_dependency_context(broker, app, asgi_state)
@@ -62,7 +61,6 @@ def shutdown_event_generator(
     async def shutdown(state: TaskiqState) -> None:
         if not broker.is_worker_process:
             return
-        await state.fastapi_app.router.shutdown()
         await state.lf_ctx.__aexit__(None, None, None)
 
     return shutdown


### PR DESCRIPTION
Starlette 1.0 removed Router.startup() and Router.shutdown() methods.
The lifespan context (__aenter__/__aexit__) already handles the application lifecycle correctly.